### PR TITLE
Make AMR accept floats for MIC

### DIFF
--- a/HICF_checklist.conf
+++ b/HICF_checklist.conf
@@ -167,6 +167,6 @@
     name            antimicrobial_resistance
     description     'Comma-separated list of antibiotics to which the sampled organism displays resistance. Each antibiotic must be followed by the MIC, SIR and, optionally, the diagnostic centre. See notes.'
     type            Str
-    validation      ^((([A-Za-z0-9\-\/\(\)\s]+);([SIR]);(lt|le|eq|gt|ge)?(\d+)(;(\w+))?),?\s*)+$
+    validation      ^((([A-Za-z0-9\-\/\(\)\s]+);([SIR]);(lt|le|eq|gt|ge)?(((\d+)?\.)?\d+)(;(\w+))?),?\s*)+$
   </field>
 </checklist>


### PR DESCRIPTION
The regex for validating the antimicrobial resistance results previously expected the MIC value to be an integer, which is unrealistic. This merge fixes it to accept floats.