### PR TITLE
Fix regular expressions that define accessions

### DIFF
--- a/HICF_checklist.conf
+++ b/HICF_checklist.conf
@@ -36,14 +36,14 @@
     description     'Accession for raw data i.e. fastq/bam files.'
     type            Str
     required        1
-    validation      ^[ES]RR\d{6}$
+    validation      ^[ES]RR\d{6,}$
   </field>
   <field>
     name            sample_accession
     description     'Accession for the sample.'
     type            Str
     required        1
-    validation      ^([ES]RS\d{6}|SAM[EN][AG]?\d+)$
+    validation      ^([ES]RS\d{6,}|SAM[EN][AG]?\d+)$
   </field>
   <field>
     name            sample_description


### PR DESCRIPTION
The regular expressions that define the raw_data_accession and
sample_accession fields were both expecting 6 numerical digits. Turns
out NCBI accessions have seven. Fixed regexes accordingly.

See ENA documentation for the accession definitions:

  https://www.ebi.ac.uk/ena/submit/accession-number-formats